### PR TITLE
make the text unselectable in desktop mode/view

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -24,6 +24,10 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 body, html {


### PR DESCRIPTION
I noticed when in Home screen or in Leaderboard that I can select the text, then I tried to other pages and they can be selected except on main game itself.

PS:
I titled it with "desktop mode/view" but it actually also apply in other display

<img width="599" height="740" alt="image" src="https://github.com/user-attachments/assets/f511b93c-54a4-4032-8e36-76c7e1e3149d" />
