### PR TITLE
Fix: removing the context menu especially when in game

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -146,6 +146,12 @@
         console.log('About to append script to document.head');
         document.head.appendChild(script);
         console.log('Script appended to document.head');
+
+    <!-- remove the annoying context menu when right clicking (desktop) / long tap (mobile) -->
+        document.addEventListener('contextmenu', function(event) {
+            event.preventDefault();
+            return false;
+        });
     </script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 </body>


### PR DESCRIPTION
when using right button of the mouse (in game) the context menu will pop up (which is annoying and distracting)
<img width="1919" height="922" alt="image" src="https://github.com/user-attachments/assets/64dc72c3-7372-4a5c-b9a1-65773d291841" />
<img width="1919" height="934" alt="image" src="https://github.com/user-attachments/assets/9c954a24-a793-4e0e-a33e-0a9b074674fe" />
